### PR TITLE
Updated setup.py to reference README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="James Davenport",
     # author_email="",
     description="Cubehelix colormaps for matplotlib",
-    long_description=read('README.rst'),
+    long_description=read('README.md'),
     # license="BSD",
     py_modules=['cubehelix'],
     classifiers=[


### PR DESCRIPTION
instead of README.rst (no longer present). Otherwise `python setup.py install` fails to find README.rst.
